### PR TITLE
Fix velocity rotation bug

### DIFF
--- a/src/workflow_tools/boundary.py
+++ b/src/workflow_tools/boundary.py
@@ -5,7 +5,7 @@ import numpy as np
 import xarray
 from loguru import logger
 
-from workflow_tools.grid import reuse_regrid
+from .grid import reuse_regrid
 
 # ignore pandas FutureWarnings raised multiple times by xarray
 warnings.simplefilter(action='ignore', category=FutureWarning)
@@ -21,19 +21,37 @@ def check_angle_range(angle):
         )
 
 
-def rotate_uv(u, v, angle):
+def rotate_uv(uearth, vearth, angle_earth_to_model_rad):
     """Rotate velocities from earth-relative to model-relative.
+    Inputs should be velocity component in true east direction (uearth)
+    and true north direction (vearth), and the angle in radians in the standard
+    (counterclockwise) direction from the true east/north
+    direction to the model east/north direction.
+    For example, if the model east was aligned with the
+    true northeast, the angle would be +pi/4 (45 deg).
+    This function does a counterclockwise rotation of the
+    coordinates, which is equivalent to a clockwise
+    rotation of the vector.
+    See https://mathworld.wolfram.com/RotationMatrix.html for a refresher
+    on how this works.
 
     Args:
-        u: west-east component of velocity.
-        v: south-north component of velocity.
-        angle: angle of rotation from true north to model north.
+        uearth: west-east component of velocity.
+        vearth: south-north component of velocity.
+        angle_earth_to_model_rad: angle of rotation
+            from true north to model north [radians].
 
     Returns:
         Model-relative west-east and south-north components of velocity.
     """
-    urot = np.cos(angle) * u - np.sin(angle) * v
-    vrot = np.sin(angle) * u + np.cos(angle) * v
+    urot = (
+        np.cos(angle_earth_to_model_rad) * uearth
+        + np.sin(angle_earth_to_model_rad) * vearth
+    )
+    vrot = (
+        -np.sin(angle_earth_to_model_rad) * uearth
+        + np.cos(angle_earth_to_model_rad) * vearth
+    )
     return urot, vrot
 
 

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -1,0 +1,14 @@
+import numpy as np
+from pytest import approx
+
+from workflow_tools import boundary
+
+
+def test_rotate_uv():
+    """
+    Most basic test following the explanation at
+    https://github.com/NOAA-GFDL/CEFI-regional-MOM6/pull/94#pullrequestreview-2318247618
+    """
+    urot, vrot = boundary.rotate_uv(0, 1, np.pi / 2)
+    assert approx(urot) == 1.0
+    assert approx(vrot) == 0.0


### PR DESCRIPTION
The velocity rotation code unintentionally used the change that was proposed in NOAA-GFDL/CEFI-regional-MOM6#94, which turned out to be incorrect. This PR uses the correct boundary code from the current CEFI-regional-MOM6, and adds a simple test to verify the explanation of rotation in the cancelled PR. 